### PR TITLE
feat: 活動 - 活動報名與留言板 API 資料庫設計

### DIFF
--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -22,6 +22,7 @@ const getMessagesByEventId = async (req, res) => {
         createdAt: messages.createdAt,
         userId: messages.userId,
         userNickname: usersTable.nickname,
+        userAvatarUrl: usersTable.avatarUrl
       })
       .from(messages)
       .leftJoin(usersTable, eq(messages.userId, usersTable.id))

--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -10,6 +10,18 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 const tz = 'Asia/Taipei';
 
+const checkIfUserJoinedEvent = async (userId, eventId) => {
+  const [hasJoined] = await db
+    .select()
+    .from(userEventParticipationTable)
+    .where(
+      and(
+        eq(userEventParticipationTable.userId, userId),
+        eq(userEventParticipationTable.eventId, eventId)
+      )
+    );
+  return !!hasJoined;
+};
 
 const getMessagesByEventId = async (req, res) => {
   const eventId = req.params.id;
@@ -50,15 +62,7 @@ const postMessageToEvent = async (req, res) => {
   }
 
   try {
-    const [hasJoined] = await db
-      .select()
-      .from(userEventParticipationTable)
-      .where(
-        and(
-          eq(userEventParticipationTable.userId, userId),
-          eq(userEventParticipationTable.eventId, eventId)
-        )
-      );
+    const hasJoined = await checkIfUserJoinedEvent(userId, eventId);
 
     if (!hasJoined) {
       return res.status(403).json({ message: '只有已報名活動的使用者才能留言' });
@@ -106,15 +110,7 @@ const updateMessage = async (req, res) => {
   }
 
   try {
-    const [hasJoined] = await db
-      .select()
-      .from(userEventParticipationTable)
-      .where(
-        and(
-          eq(userEventParticipationTable.userId, userId),
-          eq(userEventParticipationTable.eventId, eventId)
-        )
-      );
+    const hasJoined = await checkIfUserJoinedEvent(userId, eventId);
 
     if (!hasJoined) {
       return res.status(403).json({ message: '只有已報名活動的使用者才能修改留言' });
@@ -136,15 +132,7 @@ const deleteMessage = async (req, res) => {
   const userId = req.user?.id;
 
   try {
-    const [hasJoined] = await db
-      .select()
-      .from(userEventParticipationTable)
-      .where(
-        and(
-          eq(userEventParticipationTable.userId, userId),
-          eq(userEventParticipationTable.eventId, eventId)
-        )
-      );
+    const hasJoined = await checkIfUserJoinedEvent(userId, eventId);
 
     if (!hasJoined) {
       return res.status(403).json({ message: '只有已報名活動的使用者才能刪除留言' });

--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -111,7 +111,8 @@ const postMessageToEvent = async (req, res) => {
 };
 
 const updateMessage = async (req, res) => {
-  const { messageId, id: eventId } = req.params;
+  const messageId = BigInt(req.params.messageId);
+  const eventId = BigInt(req.params.id);
   const userId = req.user?.id;
   const { content } = req.body;
 
@@ -138,7 +139,8 @@ const updateMessage = async (req, res) => {
 };
 
 const deleteMessage = async (req, res) => {
-  const { messageId, id: eventId } = req.params;
+  const messageId = BigInt(req.params.messageId);
+  const eventId = BigInt(req.params.id);
   const userId = req.user?.id;
 
   try {

--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -45,6 +45,9 @@ const postMessageToEvent = async (req, res) => {
   if (!content || content.trim() === '') {
     return res.status(400).json({ message: '留言內容不可為空' });
   }
+  if (content.trim().length > 200) {
+    return res.status(400).json({ message: '留言長度不得超過 200 字' });
+  }
 
   try {
     await db.insert(messages).values({

--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -25,7 +25,8 @@ const getMessagesByEventId = async (req, res) => {
       })
       .from(messages)
       .leftJoin(usersTable, eq(messages.userId, usersTable.id))
-      .where(eq(messages.eventId, eventId));
+      .where(eq(messages.eventId, eventId))
+      .orderBy(messages.createdAt);
 
     res.status(200).json({ message: '留言取得成功', messages: result });
   } catch (err) {

--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -59,7 +59,43 @@ const postMessageToEvent = async (req, res) => {
   }
 };
 
+const updateMessage = async (req, res) => {
+  const { messageId } = req.params;
+  const { content } = req.body;
+
+  if (!content || content.trim() === '') {
+    return res.status(400).json({ message: '留言內容不可為空' });
+  }
+
+  try {
+    await db.update(messages)
+      .set({ content: content.trim() })
+      .where(eq(messages.id, messageId));
+
+    res.status(200).json({ message: '留言已更新' });
+  } catch (err) {
+    console.error('更新留言錯誤:', err);
+    res.status(500).json({ message: '伺服器錯誤' });
+  }
+};
+
+const deleteMessage = async (req, res) => {
+  const { messageId } = req.params;
+
+  try {
+    await db.delete(messages)
+      .where(eq(messages.id, messageId));
+
+    res.status(200).json({ message: '留言已刪除' });
+  } catch (err) {
+    console.error('刪除留言錯誤:', err);
+    res.status(500).json({ message: '伺服器錯誤' });
+  }
+};
+
 module.exports = {
   getMessagesByEventId,
-  postMessageToEvent
+  postMessageToEvent,
+  updateMessage,
+  deleteMessage
 };

--- a/src/controllers/joinEventController.js
+++ b/src/controllers/joinEventController.js
@@ -1,0 +1,51 @@
+const db = require('../config/db');
+const { userEventParticipationTable, events } = require('../models/schema');
+const { eq } = require('drizzle-orm');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+const tz = 'Asia/Taipei';
+
+// 🚧 待導入金流驗證後，補上付款驗證邏輯
+const joinEvent = async (req, res) => {
+  const eventId = req.params.id;
+  const userId = req.user?.id;
+
+  try {
+    const [event] = await db.select().from(events).where(eq(events.id, eventId));
+    if (!event) {
+      return res.status(404).json({ message: '找不到活動' });
+    }
+
+    const [existing] = await db
+      .select()
+      .from(userEventParticipationTable)
+      .where(
+        eq(userEventParticipationTable.userId, userId),
+        eq(userEventParticipationTable.eventId, eventId)
+      );
+
+    if (existing) {
+      return res.status(400).json({ message: '你已報名過此活動' });
+    }
+
+    // 🚧 未來導入金流驗證後請替換
+    await db.insert(userEventParticipationTable).values({
+      userId,
+      eventId,
+      joinedAt: dayjs().tz(tz).toDate(),
+    });
+
+    res.status(200).json({ message: '報名成功（測試階段，尚未接入金流）' });
+  } catch (err) {
+    console.error('報名活動時發生錯誤:', err);
+    res.status(500).json({ message: '伺服器錯誤' });
+  }
+};
+
+module.exports = {
+  joinEvent
+};

--- a/src/controllers/joinEventController.js
+++ b/src/controllers/joinEventController.js
@@ -13,7 +13,11 @@ const tz = 'Asia/Taipei';
 const joinEvent = async (req, res) => {
   const eventId = req.params.id;
   const userId = req.user?.id;
-
+  
+  if (!userId) {
+    return res.status(401).json({ message: '未授權的請求，請先登入' });
+  }
+  
   try {
     const [event] = await db.select().from(events).where(eq(events.id, eventId));
     if (!event) {

--- a/src/controllers/joinEventController.js
+++ b/src/controllers/joinEventController.js
@@ -1,6 +1,6 @@
 const db = require('../config/db');
 const { userEventParticipationTable, events } = require('../models/schema');
-const { eq } = require('drizzle-orm');
+const { eq,and } = require('drizzle-orm');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
@@ -28,8 +28,10 @@ const joinEvent = async (req, res) => {
       .select()
       .from(userEventParticipationTable)
       .where(
-        eq(userEventParticipationTable.userId, userId),
-        eq(userEventParticipationTable.eventId, eventId)
+        and(
+          eq(userEventParticipationTable.userId, userId),
+          eq(userEventParticipationTable.eventId, eventId)
+        )
       );
 
     if (existing) {

--- a/src/drizzle/migrations/0004_lovely_ultron.sql
+++ b/src/drizzle/migrations/0004_lovely_ultron.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "messages" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now(),
+	"user_id" integer NOT NULL,
+	"event_id" bigint NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "messages" ADD CONSTRAINT "messages_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE no action ON UPDATE no action;

--- a/src/drizzle/migrations/0005_strong_meteorite.sql
+++ b/src/drizzle/migrations/0005_strong_meteorite.sql
@@ -1,0 +1,35 @@
+CREATE TABLE "orders" (
+	"id" bigint PRIMARY KEY NOT NULL,
+	"order_number" varchar(255) NOT NULL,
+	"user_id" integer,
+	"total_amount" integer NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"payment_method" varchar(20),
+	"payment_id" varchar(255),
+	"paid_at" timestamp with time zone,
+	"cancelled_at" timestamp with time zone,
+	"cancellation_reason" varchar(255),
+	"created_at" timestamp with time zone DEFAULT now(),
+	"updated_at" timestamp with time zone DEFAULT now(),
+	CONSTRAINT "orders_order_number_unique" UNIQUE("order_number")
+);
+--> statement-breakpoint
+CREATE TABLE "order_items" (
+	"id" bigint PRIMARY KEY NOT NULL,
+	"order_id" bigint NOT NULL,
+	"event_id" bigint NOT NULL,
+	"event_name" varchar(255) NOT NULL,
+	"bar_name" varchar(100) NOT NULL,
+	"location" varchar(255) NOT NULL,
+	"event_start_date" timestamp with time zone NOT NULL,
+	"event_end_date" timestamp with time zone NOT NULL,
+	"host_user_id" integer NOT NULL,
+	"price" integer NOT NULL,
+	"quantity" integer NOT NULL,
+	"subtotal" integer NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "messages" ALTER COLUMN "id" SET DATA TYPE bigint;--> statement-breakpoint
+ALTER TABLE "orders" ADD CONSTRAINT "orders_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_order_id_orders_id_fk" FOREIGN KEY ("order_id") REFERENCES "public"."orders"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE restrict ON UPDATE no action;

--- a/src/drizzle/migrations/meta/0004_snapshot.json
+++ b/src/drizzle/migrations/meta/0004_snapshot.json
@@ -1,0 +1,980 @@
+{
+  "id": "3da0b3a2-9650-4d91-b242-31cde0986370",
+  "prevId": "d6c6f579-174b-4679-be10-6ed400f62308",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_display_name": {
+          "name": "line_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_picture_url": {
+          "name": "line_picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_status_message": {
+          "name": "line_status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_line_user": {
+          "name": "is_line_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_verified_email": {
+          "name": "is_verified_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_last_updated": {
+          "name": "avatar_last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification": {
+      "name": "user_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_user_id_users_id_fk": {
+          "name": "user_notification_user_id_users_id_fk",
+          "tableFrom": "user_notification",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bars": {
+      "name": "bars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_hours": {
+          "name": "open_hours",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_bar_folders": {
+      "name": "user_bar_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_bar_folders_user_id_users_id_fk": {
+          "name": "user_bar_folders_user_id_users_id_fk",
+          "tableFrom": "user_bar_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_bar_folders_user_id_folder_name_unique": {
+          "name": "user_bar_folders_user_id_folder_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "folder_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_bar_collection": {
+      "name": "user_bar_collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bar_id": {
+          "name": "bar_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_bar_collection_user_id_users_id_fk": {
+          "name": "user_bar_collection_user_id_users_id_fk",
+          "tableFrom": "user_bar_collection",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bar_collection_bar_id_bars_id_fk": {
+          "name": "user_bar_collection_bar_id_bars_id_fk",
+          "tableFrom": "user_bar_collection",
+          "tableTo": "bars",
+          "columnsFrom": [
+            "bar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bar_collection_folder_id_user_bar_folders_id_fk": {
+          "name": "user_bar_collection_folder_id_user_bar_folders_id_fk",
+          "tableFrom": "user_bar_collection",
+          "tableTo": "user_bar_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_bar_collection_user_id_bar_id_unique": {
+          "name": "user_bar_collection_user_id_bar_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "bar_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_event_collection": {
+      "name": "user_event_collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_event_collection_user_id_users_id_fk": {
+          "name": "user_event_collection_user_id_users_id_fk",
+          "tableFrom": "user_event_collection",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_event_collection_event_id_events_id_fk": {
+          "name": "user_event_collection_event_id_events_id_fk",
+          "tableFrom": "user_event_collection",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_event_collection_folder_id_user_event_folders_id_fk": {
+          "name": "user_event_collection_folder_id_user_event_folders_id_fk",
+          "tableFrom": "user_event_collection",
+          "tableTo": "user_event_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_event_collection_user_id_event_id_unique": {
+          "name": "user_event_collection_user_id_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_event_participation": {
+      "name": "user_event_participation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_event_participation_user_id_users_id_fk": {
+          "name": "user_event_participation_user_id_users_id_fk",
+          "tableFrom": "user_event_participation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_event_participation_event_id_events_id_fk": {
+          "name": "user_event_participation_event_id_events_id_fk",
+          "tableFrom": "user_event_participation",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_event_participation_user_id_event_id_unique": {
+          "name": "user_event_participation_user_id_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_event_folders": {
+      "name": "user_event_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_event_folders_user_id_users_id_fk": {
+          "name": "user_event_folders_user_id_users_id_fk",
+          "tableFrom": "user_event_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_event_folders_user_id_folder_name_unique": {
+          "name": "user_event_folders_user_id_folder_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "folder_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bar_name": {
+          "name": "bar_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_people": {
+          "name": "max_people",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_user": {
+          "name": "host_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_at": {
+          "name": "modify_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_host_user": {
+          "name": "idx_host_user",
+          "columns": [
+            {
+              "expression": "host_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_host_user_users_id_fk": {
+          "name": "events_host_user_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_tags": {
+      "name": "event_tags",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_tags_tag_id_tags_id_fk": {
+          "name": "event_tags_tag_id_tags_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_tags_event_id_tag_id_pk": {
+          "name": "event_tags_event_id_tag_id_pk",
+          "columns": [
+            "event_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_event_id_events_id_fk": {
+          "name": "messages_event_id_events_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/migrations/meta/0005_snapshot.json
+++ b/src/drizzle/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1202 @@
+{
+  "id": "7f06fcd9-e931-489f-a0ee-f5829dfcaf48",
+  "prevId": "3da0b3a2-9650-4d91-b242-31cde0986370",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_user_id": {
+          "name": "line_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_display_name": {
+          "name": "line_display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_picture_url": {
+          "name": "line_picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line_status_message": {
+          "name": "line_status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_line_user": {
+          "name": "is_line_user",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_verified_email": {
+          "name": "is_verified_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_last_updated": {
+          "name": "avatar_last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_line_user_id_unique": {
+          "name": "users_line_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "line_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification": {
+      "name": "user_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_user_id_users_id_fk": {
+          "name": "user_notification_user_id_users_id_fk",
+          "tableFrom": "user_notification",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bars": {
+      "name": "bars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_hours": {
+          "name": "open_hours",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_bar_folders": {
+      "name": "user_bar_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_bar_folders_user_id_users_id_fk": {
+          "name": "user_bar_folders_user_id_users_id_fk",
+          "tableFrom": "user_bar_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_bar_folders_user_id_folder_name_unique": {
+          "name": "user_bar_folders_user_id_folder_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "folder_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_bar_collection": {
+      "name": "user_bar_collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bar_id": {
+          "name": "bar_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_bar_collection_user_id_users_id_fk": {
+          "name": "user_bar_collection_user_id_users_id_fk",
+          "tableFrom": "user_bar_collection",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bar_collection_bar_id_bars_id_fk": {
+          "name": "user_bar_collection_bar_id_bars_id_fk",
+          "tableFrom": "user_bar_collection",
+          "tableTo": "bars",
+          "columnsFrom": [
+            "bar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_bar_collection_folder_id_user_bar_folders_id_fk": {
+          "name": "user_bar_collection_folder_id_user_bar_folders_id_fk",
+          "tableFrom": "user_bar_collection",
+          "tableTo": "user_bar_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_bar_collection_user_id_bar_id_unique": {
+          "name": "user_bar_collection_user_id_bar_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "bar_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_event_collection": {
+      "name": "user_event_collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_event_collection_user_id_users_id_fk": {
+          "name": "user_event_collection_user_id_users_id_fk",
+          "tableFrom": "user_event_collection",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_event_collection_event_id_events_id_fk": {
+          "name": "user_event_collection_event_id_events_id_fk",
+          "tableFrom": "user_event_collection",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_event_collection_folder_id_user_event_folders_id_fk": {
+          "name": "user_event_collection_folder_id_user_event_folders_id_fk",
+          "tableFrom": "user_event_collection",
+          "tableTo": "user_event_folders",
+          "columnsFrom": [
+            "folder_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_event_collection_user_id_event_id_unique": {
+          "name": "user_event_collection_user_id_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_event_participation": {
+      "name": "user_event_participation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_event_participation_user_id_users_id_fk": {
+          "name": "user_event_participation_user_id_users_id_fk",
+          "tableFrom": "user_event_participation",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_event_participation_event_id_events_id_fk": {
+          "name": "user_event_participation_event_id_events_id_fk",
+          "tableFrom": "user_event_participation",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_event_participation_user_id_event_id_unique": {
+          "name": "user_event_participation_user_id_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_event_folders": {
+      "name": "user_event_folders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_event_folders_user_id_users_id_fk": {
+          "name": "user_event_folders_user_id_users_id_fk",
+          "tableFrom": "user_event_folders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_event_folders_user_id_folder_name_unique": {
+          "name": "user_event_folders_user_id_folder_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "folder_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bar_name": {
+          "name": "bar_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_people": {
+          "name": "max_people",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_user": {
+          "name": "host_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modify_at": {
+          "name": "modify_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_host_user": {
+          "name": "idx_host_user",
+          "columns": [
+            {
+              "expression": "host_user",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_host_user_users_id_fk": {
+          "name": "events_host_user_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "host_user"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_tags": {
+      "name": "event_tags",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_tags_tag_id_tags_id_fk": {
+          "name": "event_tags_tag_id_tags_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "event_tags_event_id_tag_id_pk": {
+          "name": "event_tags_event_id_tag_id_pk",
+          "columns": [
+            "event_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "orders_user_id_users_id_fk": {
+          "name": "orders_user_id_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "order_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bar_name": {
+          "name": "bar_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_start_date": {
+          "name": "event_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_end_date": {
+          "name": "event_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": [
+            "order_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_event_id_events_id_fk": {
+          "name": "order_items_event_id_events_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_event_id_events_id_fk": {
+          "name": "messages_event_id_events_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/migrations/meta/_journal.json
+++ b/src/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1749479687826,
       "tag": "0003_melted_the_phantom",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1749809169489,
+      "tag": "0004_lovely_ultron",
+      "breakpoints": true
     }
   ]
 }

--- a/src/drizzle/migrations/meta/_journal.json
+++ b/src/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1749809169489,
       "tag": "0004_lovely_ultron",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1750000221149,
+      "tag": "0005_strong_meteorite",
+      "breakpoints": true
     }
   ]
 }

--- a/src/middlewares/isMessageOwner.js
+++ b/src/middlewares/isMessageOwner.js
@@ -1,0 +1,30 @@
+const db = require('../config/db');
+const { messages } = require('../models/schema');
+const { eq } = require('drizzle-orm');
+
+const isMessageOwner = async (req, res, next) => {
+  const userId = req.user?.id;
+  const messageId = req.params.messageId;
+
+  try {
+    const [msg] = await db
+      .select()
+      .from(messages)
+      .where(eq(messages.id, messageId));
+
+    if (!msg) {
+      return res.status(404).json({ message: '留言不存在' });
+    }
+
+    if (msg.userId !== userId) {
+      return res.status(403).json({ message: '無權限操作此留言' });
+    }
+
+    next();
+  } catch (err) {
+    console.error('權限檢查失敗:', err);
+    return res.status(500).json({ message: '伺服器錯誤' });
+  }
+};
+
+module.exports = isMessageOwner;

--- a/src/middlewares/isMessageOwner.js
+++ b/src/middlewares/isMessageOwner.js
@@ -6,6 +6,10 @@ const isMessageOwner = async (req, res, next) => {
   const userId = req.user?.id;
   const messageId = req.params.messageId;
 
+  if (!userId) {
+    return res.status(401).json({ message: '未經授權，請先登入' });
+  }
+  
   try {
     const [msg] = await db
       .select()

--- a/src/models/schema.js
+++ b/src/models/schema.js
@@ -131,6 +131,13 @@ const eventTags = pgTable('event_tags', {
   pk: primaryKey({ columns: [table.eventId, table.tagId] })
 }));
 
+// src/models/schema.js
+const messages = pgTable('messages', {
+  id: serial('id').primaryKey(),
+  content: text('content').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  userId: integer('user_id').references(() => usersTable.id, { onDelete: 'cascade' }).notNull(),
+  eventId: bigint('event_id', { mode: 'string' }).references(() => events.id).notNull()
+});
 
-
-module.exports = { usersTable, userNotificationTable, barsTable, userBarFoldersTable, userBarCollectionTable, userEventCollectionTable, userEventParticipationTable, userEventFoldersTable, events, tags, eventTags };
+module.exports = { usersTable, userNotificationTable, barsTable, userBarFoldersTable, userBarCollectionTable, userEventCollectionTable, userEventParticipationTable, userEventFoldersTable, events, tags, eventTags, messages };

--- a/src/routes/eventMessageRoutes.js
+++ b/src/routes/eventMessageRoutes.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+
+const {
+  getMessagesByEventId,
+  postMessageToEvent
+} = require('../controllers/eventMessageController');
+
+const authenticateToken = require('../middlewares/authenticateToken');
+
+router.get('/', getMessagesByEventId);
+
+router.post('/', authenticateToken, postMessageToEvent);
+
+module.exports = router;

--- a/src/routes/eventMessageRoutes.js
+++ b/src/routes/eventMessageRoutes.js
@@ -3,13 +3,20 @@ const router = express.Router({ mergeParams: true });
 
 const {
   getMessagesByEventId,
-  postMessageToEvent
+  postMessageToEvent,
+  updateMessage,
+  deleteMessage
 } = require('../controllers/eventMessageController');
 
 const authenticateToken = require('../middlewares/authenticateToken');
+const isMessageOwner = require('../middlewares/isMessageOwner');
 
 router.get('/', getMessagesByEventId);
 
 router.post('/', authenticateToken, postMessageToEvent);
+
+router.put('/:messageId', authenticateToken, isMessageOwner, updateMessage);
+
+router.delete('/:messageId', authenticateToken, isMessageOwner, deleteMessage);
 
 module.exports = router;

--- a/src/routes/eventRoutes.js
+++ b/src/routes/eventRoutes.js
@@ -1,15 +1,25 @@
 const express = require('express');
-const { createEvent, getEvent, updateEvent, softDeleteEvent, getAllEvents } = require('../controllers/eventControllers');
+const {
+  createEvent,
+  getEvent,
+  updateEvent,
+  softDeleteEvent,
+  getAllEvents
+} = require('../controllers/eventControllers');
+
+const { joinEvent } = require('../controllers/joinEventController');
+const eventMessageRoutes = require('./eventMessageRoutes');
 
 const router = express.Router();
-const eventMessageRoutes = require('./eventMessageRoutes');
 
 router.get('/all', getAllEvents);
 router.post('/create', createEvent);
+
+router.post('/:id/join', joinEvent);
+router.use('/:id/messages', eventMessageRoutes);
+
 router.get('/:id', getEvent);
 router.put('/update/:id', updateEvent);
 router.delete('/delete/:id', softDeleteEvent);
-
-router.use('/:id/messages', eventMessageRoutes);
 
 module.exports = router;

--- a/src/routes/eventRoutes.js
+++ b/src/routes/eventRoutes.js
@@ -9,13 +9,14 @@ const {
 
 const { joinEvent } = require('../controllers/joinEventController');
 const eventMessageRoutes = require('./eventMessageRoutes');
+const authenticateToken = require('../middlewares/authenticateToken');
 
 const router = express.Router();
 
 router.get('/all', getAllEvents);
 router.post('/create', createEvent);
 
-router.post('/:id/join', joinEvent);
+router.post('/:id/join', authenticateToken, joinEvent);
 router.use('/:id/messages', eventMessageRoutes);
 
 router.get('/:id', getEvent);

--- a/src/routes/eventRoutes.js
+++ b/src/routes/eventRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { createEvent, getEvent, updateEvent, softDeleteEvent, getAllEvents } = require('../controllers/eventControllers');
 
 const router = express.Router();
+const eventMessageRoutes = require('./eventMessageRoutes');
 
 router.get('/all', getAllEvents);
 router.post('/create', createEvent);
@@ -9,5 +10,6 @@ router.get('/:id', getEvent);
 router.put('/update/:id', updateEvent);
 router.delete('/delete/:id', softDeleteEvent);
 
+router.use('/:id/messages', eventMessageRoutes);
 
 module.exports = router;

--- a/src/routes/eventRoutes.js
+++ b/src/routes/eventRoutes.js
@@ -14,13 +14,13 @@ const authenticateToken = require('../middlewares/authenticateToken');
 const router = express.Router();
 
 router.get('/all', getAllEvents);
-router.post('/create', createEvent);
+router.post('/create', authenticateToken, createEvent);
 
 router.post('/:id/join', authenticateToken, joinEvent);
 router.use('/:id/messages', eventMessageRoutes);
 
 router.get('/:id', getEvent);
-router.put('/update/:id', updateEvent);
-router.delete('/delete/:id', softDeleteEvent);
+router.put('/update/:id', authenticateToken, updateEvent);
+router.delete('/delete/:id', authenticateToken, softDeleteEvent);
 
 module.exports = router;

--- a/src/routes/eventRoutes.js
+++ b/src/routes/eventRoutes.js
@@ -20,7 +20,7 @@ router.post('/:id/join', authenticateToken, joinEvent);
 router.use('/:id/messages', eventMessageRoutes);
 
 router.get('/:id', getEvent);
-router.put('/update/:id', authenticateToken, updateEvent);
-router.delete('/delete/:id', authenticateToken, softDeleteEvent);
+router.put('/:id/update', authenticateToken, updateEvent);
+router.delete('/:id/delete', authenticateToken, softDeleteEvent);
 
 module.exports = router;


### PR DESCRIPTION
##  PR 類型 (Type of Change)

- [x] 新功能 (Feature)

## 說明

### 建立「活動報名」功能及 API：

- 新增 `joinEventController.js`，實作使用者報名活動的邏輯
- 報名成功條件暫以登入身分判定，未來將串接金流驗證（註解已預留待補)
- 新增報名記錄資料至 `userEventParticipationTable`（基於 `userId` 與 `eventId`）
- 在 `eventRoutes.js` 中新增 POST /:id/join 路由並掛載 `controller`

### 建立「活動留言板」的資料表與後端 API 功能：

- 新增 messages schema 至 `models/schema.js`
- 新增 `eventMessageController.js`，實作 CRUD 功能
- 新增 `eventMessageRoutes.js`，串接對應留言路由
- 在 `eventRoutes.js` 中掛載子路由 /:id/messages
- 加入留言防洗版邏輯（時間限制＋內容重複判斷）

## api測試方式
#### 1. 使用者登入，取得 JWT token
**POST** ` http://localhost:3000/api/auth/login`
```
{
  "email": "testuser@example.com",
  "password": "Aa12345678"
}
```
#### 2. 建立活動（需要登入）
**POST** `http://localhost:3000/api/event/create`
```
{
  "name": "測試活動",
  "barName": "JOINBAR",
  "location": "台北市中正區",
  "startDate": "2025-07-01T18:00:00.000Z",
  "endDate": "2025-07-01T21:00:00.000Z",
  "maxPeople": 10,
  "price": 300,
  "hostUser": "你的登入 userId",
  "tags": [1, 2]
}
```
#### 3. 報名活動（需要登入）
**POST** `http://localhost:3000/api/event/ {{ eventId }} /join`

#### 4. 新增留言（需要報名）
**POST** `http://localhost:3000/api/event/ {{ eventId }} /messages`
```
{
  "content": "這是一則測試留言"
}
```
## 🔗 關聯 Issue (Related Issue)

Closes #10 