### PR TITLE
refactor: 活動 - 重構活動留言板相關邏輯

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-BigInt.prototype.toJSON = function() {
-  return this.toString();
-};
-
 const express = require('express');
 const dotenv = require('dotenv');
 const multer = require('multer');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+BigInt.prototype.toJSON = function() {
+  return this.toString();
+};
+
 const express = require('express');
 const dotenv = require('dotenv');
 const multer = require('multer');

--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -1,47 +1,28 @@
+const FlakeId = require('flake-idgen');
 const db = require('../config/db');
-const { messages, usersTable, userEventParticipationTable } = require('../models/schema');
-const { eq, desc, and } = require('drizzle-orm');
+const { messages, usersTable, events } = require('../models/schema');
+const { eq, and } = require('drizzle-orm');
 
-const dayjs = require('dayjs');
-const utc = require('dayjs/plugin/utc');
-const timezone = require('dayjs/plugin/timezone');
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
-const tz = 'Asia/Taipei';
-
-const checkIfUserJoinedEvent = async (userId, eventId) => {
-  const [hasJoined] = await db
-    .select()
-    .from(userEventParticipationTable)
-    .where(
-      and(
-        eq(userEventParticipationTable.userId, userId),
-        eq(userEventParticipationTable.eventId, eventId)
-      )
-    );
-  return !!hasJoined;
-};
-
-const getLastMessageByUserId = async (userId, eventId) => {
-  const [lastMessage] = await db
-    .select()
-    .from(messages)
-    .where(
-      and(
-        eq(messages.userId, userId),
-        eq(messages.eventId, eventId)
-      )
-    )
-    .orderBy(desc(messages.createdAt))
-    .limit(1);
-  return lastMessage || null;
-};
+const flake = new FlakeId({ id: 1 });
 
 const getMessagesByEventId = async (req, res) => {
-  const eventId = BigInt(req.params.id);
+	const eventId = req.params.id;
 
-  try {
+	try {
+		const [event] = await db
+      .select()
+      .from(events)
+      .where(and(
+        eq(events.id, eventId),
+        eq(events.status, 1)
+      ))
+      .limit(1);
+
+		if (!event) {
+      return res.status(404).json({ message: '活動不存在或已刪除' });
+    }
+
+		// 取得該活動的所有留言
     const result = await db
       .select({
         id: messages.id,
@@ -56,113 +37,17 @@ const getMessagesByEventId = async (req, res) => {
       .where(eq(messages.eventId, eventId))
       .orderBy(messages.createdAt);
 
-    res.status(200).json({ message: '留言取得成功', messages: result });
-  } catch (err) {
-    console.error('取得留言時發生錯誤:', err);
-    res.status(500).json({ message: '伺服器錯誤' });
-  }
-};
-
-
-const postMessageToEvent = async (req, res) => {
-  const eventId = BigInt(req.params.id);
-  const userId = req.user?.id;
-  const { content } = req.body;
-
-  if (!content || content.trim() === '') {
-    return res.status(400).json({ message: '留言內容不可為空' });
-  }
-  if (content.trim().length > 200) {
-    return res.status(400).json({ message: '留言長度不得超過 200 字' });
-  }
-
-  try {
-    const hasJoined = await checkIfUserJoinedEvent(userId, eventId);
-
-    if (!hasJoined) {
-      return res.status(403).json({ message: '只有已報名活動的使用者才能留言' });
-    }
-
-    const lastMessage = await getLastMessageByUserId(userId, eventId);
-
-    if (lastMessage) {
-      const diffInSeconds = (Date.now() - new Date(lastMessage.createdAt)) / 1000;
-      if (diffInSeconds < 10) {
-        return res.status(429).json({ message: '請勿頻繁留言，請稍後再試。' });
+    res.status(200).json({ 
+      message: '留言取得成功', 
+      messages: result,
+      eventInfo: {
+        id: event.id,
+        name: event.name,
+        status: event.status
       }
-
-      if (lastMessage.content === content.trim()) {
-        return res.status(400).json({ message: '請勿重複留言相同內容' });
-      }
-    }
-
-    await db.insert(messages).values({
-      content: content.trim(),
-      userId,
-      eventId,
-      createdAt: dayjs().tz(tz).toDate()
     });
-
-    res.status(201).json({ message: '留言已新增' });
-  } catch (err) {
-    console.error('新增留言錯誤:', err);
+	} catch(err) {
+		console.error('取得留言時發生錯誤:', err);
     res.status(500).json({ message: '伺服器錯誤' });
-  }
-};
-
-const updateMessage = async (req, res) => {
-  const messageId = BigInt(req.params.messageId);
-  const eventId = BigInt(req.params.id);
-  const userId = req.user?.id;
-  const { content } = req.body;
-
-  if (!content || content.trim() === '') {
-    return res.status(400).json({ message: '留言內容不可為空' });
-  }
-
-  try {
-    const hasJoined = await checkIfUserJoinedEvent(userId, eventId);
-
-    if (!hasJoined) {
-      return res.status(403).json({ message: '只有已報名活動的使用者才能修改留言' });
-    }
-
-    await db.update(messages)
-      .set({ content: content.trim() })
-      .where(eq(messages.id, messageId));
-
-    res.status(200).json({ message: '留言已更新' });
-  } catch (err) {
-    console.error('更新留言錯誤:', err);
-    res.status(500).json({ message: '伺服器錯誤' });
-  }
-};
-
-const deleteMessage = async (req, res) => {
-  const messageId = BigInt(req.params.messageId);
-  const eventId = BigInt(req.params.id);
-  const userId = req.user?.id;
-
-  try {
-    const hasJoined = await checkIfUserJoinedEvent(userId, eventId);
-
-    if (!hasJoined) {
-      return res.status(403).json({ message: '只有已報名活動的使用者才能刪除留言' });
-    }
-
-    await db.delete(messages)
-      .where(eq(messages.id, messageId));
-
-    res.status(200).json({ message: '留言已刪除' });
-  } catch (err) {
-    console.error('刪除留言錯誤:', err);
-    res.status(500).json({ message: '伺服器錯誤' });
-  }
-};
-
-module.exports = {
-  getMessagesByEventId,
-  postMessageToEvent,
-  updateMessage,
-  deleteMessage
+	}
 };

--- a/src/controllers/eventMessageController.js
+++ b/src/controllers/eventMessageController.js
@@ -1,7 +1,9 @@
 const FlakeId = require('flake-idgen');
 const db = require('../config/db');
 const { messages, usersTable, events } = require('../models/schema');
-const { eq, and } = require('drizzle-orm');
+const { eq, and, desc } = require('drizzle-orm');
+const { dayjs, tz } = require('../utils/dateFormatter');
+const intformat = require('biguint-format');
 
 const flake = new FlakeId({ id: 1 });
 
@@ -18,7 +20,7 @@ const getMessagesByEventId = async (req, res) => {
       ))
       .limit(1);
 
-		if (!event) {
+		if(!event) {
       return res.status(404).json({ message: '活動不存在或已刪除' });
     }
 
@@ -35,7 +37,7 @@ const getMessagesByEventId = async (req, res) => {
       .from(messages)
       .leftJoin(usersTable, eq(messages.userId, usersTable.id))
       .where(eq(messages.eventId, eventId))
-      .orderBy(messages.createdAt);
+      .orderBy(desc(messages.createdAt));
 
     res.status(200).json({ 
       message: '留言取得成功', 
@@ -50,4 +52,90 @@ const getMessagesByEventId = async (req, res) => {
 		console.error('取得留言時發生錯誤:', err);
     res.status(500).json({ message: '伺服器錯誤' });
 	}
+};
+
+const postMessageToEvent = async(req, res) => {
+  const { content } = req.body;
+  const eventId = req.params.id;
+  const userId = req.user?.id;
+
+  if(!content || content.trim() === '') {
+    return res.status(400).json({ message: '留言內容不可為空' });
+  }
+
+  if(content.trim().length > 200) {
+    return res.status(400).json({ message: '留言長度不得超過 200 字' });
+  }
+
+  try{
+    // 驗證活動是否存在或有效
+    const [event] = await db
+      .select()
+      .from(events)
+      .where(and(
+        eq(events.id, eventId),
+        eq(events.status, 1)  // 確保活動未被刪除
+      ))
+      .limit(1);
+
+    if(!event) {
+      return res.status(404).json({ message: '活動不存在或已刪除' });
+    }
+
+    const now = dayjs().tz(tz).toDate();
+    if(event.endAt < now) {
+      return res.status(400).json({ message: '活動已結束 無法留言' });
+    }
+
+    // 檢查最後一則留言時間和是否相同留言
+    const [lastMessage] = await db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.userId, userId),
+          eq(messages.eventId, eventId)
+        )
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(1);
+
+    if (lastMessage) {
+      const diffInSeconds = (Date.now() - new Date(lastMessage.createdAt)) / 1000;
+      if (diffInSeconds < 10) {
+        return res.status(429).json({ message: '請勿頻繁留言 請稍後再試' });
+      }
+
+      if (lastMessage.content === content.trim()) {
+        return res.status(400).json({ message: '請勿重複留言相同內容' });
+      }
+    }
+
+    // 雪花產ID
+    const messageId = intformat(flake.next(), 'dec');
+
+    await db.insert(messages).values({
+      id: messageId,
+      content: content.trim(),
+      userId,
+      eventId,
+      createdAt: dayjs().tz(tz).toDate()
+    });
+
+    res.status(201).json({ 
+      message: '留言已新增',
+      eventInfo: {
+        id: event.id,
+        name: event.name
+      }
+    });
+  } catch(err) {
+    console.error('新增留言錯誤:', err);
+    res.status(500).json({ message: '伺服器錯誤' });
+  }
+};
+
+module.exports = {
+  getMessagesByEventId,
+  postMessageToEvent
 };

--- a/src/routes/eventMessageRoutes.js
+++ b/src/routes/eventMessageRoutes.js
@@ -4,9 +4,10 @@ const router = express.Router({ mergeParams: true });
 const { getMessagesByEventId, postMessageToEvent } = require('../controllers/eventMessageController');
 
 const authenticateToken = require('../middlewares/authenticateToken');
+const formatApiResponse = require('../middlewares/formatApiResponse');
 
-router.get('/', getMessagesByEventId);
+router.get('/', formatApiResponse, getMessagesByEventId);
 
-router.post('/', authenticateToken, postMessageToEvent);
+router.post('/', authenticateToken, formatApiResponse, postMessageToEvent);
 
 module.exports = router;

--- a/src/routes/eventMessageRoutes.js
+++ b/src/routes/eventMessageRoutes.js
@@ -1,22 +1,12 @@
 const express = require('express');
 const router = express.Router({ mergeParams: true });
 
-const {
-  getMessagesByEventId,
-  postMessageToEvent,
-  updateMessage,
-  deleteMessage
-} = require('../controllers/eventMessageController');
+const { getMessagesByEventId, postMessageToEvent } = require('../controllers/eventMessageController');
 
 const authenticateToken = require('../middlewares/authenticateToken');
-const isMessageOwner = require('../middlewares/isMessageOwner');
 
 router.get('/', getMessagesByEventId);
 
 router.post('/', authenticateToken, postMessageToEvent);
-
-router.put('/:messageId', authenticateToken, isMessageOwner, updateMessage);
-
-router.delete('/:messageId', authenticateToken, isMessageOwner, deleteMessage);
 
 module.exports = router;


### PR DESCRIPTION
使用 mergeParams: true 支援巢狀路由繼承 eventId 參數
支援 /api/event/:id/messages 的巢狀路徑設計
主檔案 index.js 頂部加入全域設置 BigInt.prototype.toJSON 方法解決 JSON 序列化問題
排序為 desc 顯示最新留言
![截圖 2025-06-26 晚上10 46 08](https://github.com/user-attachments/assets/e6712521-0f90-49e8-abc6-958e3397c834)
![截圖 2025-06-26 晚上10 46 45](https://github.com/user-attachments/assets/21eaf215-64c4-4430-a5c8-284cfe97a13f)
![截圖 2025-06-26 晚上10 47 03](https://github.com/user-attachments/assets/7da3ced3-28ef-42df-b2b2-c4c6877064c1)
![截圖 2025-06-26 晚上10 49 09](https://github.com/user-attachments/assets/cc5ea92c-5acc-4b4f-948d-481ef18815c7)
![截圖 2025-06-26 晚上10 49 25](https://github.com/user-attachments/assets/3bda3b5c-e27b-4368-9a5f-bb78bff8e8a5)
