### PR TITLE
feat: 活動 - 活動API新增參與人數統計

### DIFF
--- a/src/controllers/eventControllers.js
+++ b/src/controllers/eventControllers.js
@@ -1,8 +1,8 @@
 const FlakeId = require('flake-idgen');
 const intformat = require('biguint-format');
 const db = require('../config/db');
-const { events, eventTags, tags, usersTable } = require('../models/schema');
-const { eq, and } = require('drizzle-orm');
+const { events, eventTags, tags, usersTable, userEventParticipationTable } = require('../models/schema');
+const { eq, and, count } = require('drizzle-orm');
 const { dayjs, tz } = require('../utils/dateFormatter');
 const { uploadImage, deleteImageByUrl } = require('../utils/firebaseUtils');
 
@@ -132,13 +132,24 @@ const getEvent = async (req, res) => {
       event.status = 3;
     }
 
+    const [participantCount] = await db
+      .select({ count: count() })
+      .from(userEventParticipationTable)
+      .where(eq(userEventParticipationTable.eventId, eventId));
+
     const getEventTags = await db
       .select({ id: tags.id, name: tags.name })
       .from(eventTags)
       .innerJoin(tags, eq(eventTags.tagId, tags.id))
       .where(eq(eventTags.eventId, eventId));
 
-    res.status(200).json({ event, tags: getEventTags });
+    res.status(200).json({ 
+      event: {
+        ...event,
+        currentParticipants: participantCount.count
+      }, 
+      tags: getEventTags 
+    });
   } catch (err) {
     console.error('getEvent 錯誤:', err);
     return res.status(500).json({ message: '伺服器錯誤' });
@@ -159,7 +170,6 @@ const updateEvent = async (req, res) => {
     const imageFile = req.file;
     let imageUrl = event.imageUrl;
 
-    // 檢查圖片欄位格式
     if (req.body.image && !imageFile) {
       return res.status(400).json({
         message: '圖片格式錯誤，請上傳 jpeg/png/webp/jfif',
@@ -183,7 +193,7 @@ const updateEvent = async (req, res) => {
 
     if (imageFile) {
       try {
-        await deleteImageByUrl(imageUrl); // 先刪原圖
+        await deleteImageByUrl(imageUrl); 
         imageUrl = await uploadImage(
           imageFile.buffer,
           imageFile.mimetype,


### PR DESCRIPTION
### 問題
活動頁面顯示參與人數固定為0，無法反映實際報名狀況

### 解決方案
在 `getEvent` API 中查詢 `userEventParticipationTable` 並返回實際參與人數

### 修改內容
- 新增參與人數查詢邏輯
- API 回應新增 `currentParticipants` 欄位

### 測試
- [x] API 返回正確的參與人數
- [x] 付款完成後人數正確更新

### 影響範圍
僅修改 `src/controllers/eventControllers.js` 中的 `getEvent` 函數

前端關聯PR: #145